### PR TITLE
ROCANA-1951 Add Windows CPU metrics

### DIFF
--- a/pdh_windows.go
+++ b/pdh_windows.go
@@ -1,0 +1,118 @@
+package sigar
+
+/* These are convenience methods for extracting metrics from the Windows
+   Performance Data Helper (PDH) library */
+
+import (
+	"fmt"
+	"github.com/scalingdata/win"
+)
+
+/* Run the set of provided queries once and report back the raw counter values for each.
+   Queries must have a wildcard, like `\Processor(*)\% idle time`. Returns a map of
+   wildcard values to arrays of results. The indices in the array match up with the
+   index of the query in `queries`. */
+func runRawPdhArrayQueries(queries []string) (map[string][]uint64, error) {
+	var query win.PDH_HQUERY
+	counters := make([]win.PDH_HCOUNTER, len(queries))
+	results := make(map[string][]uint64, len(queries))
+	// Open a new query
+	err := win.PdhOpenQuery(0, 0, &query)
+	if err != 0 {
+		return nil, fmt.Errorf("Error opening PDH query: %X", err)
+	}
+
+	// Add all of the counters. If any fail, give up.
+	for i := 0; i < len(queries); i++ {
+		err = win.PdhAddEnglishCounter(query, queries[i], 0, &counters[i])
+		if err != 0 {
+			win.PdhCloseQuery(query)
+			return nil, fmt.Errorf("Error calling AddCounter for metric %v: %X", queries[i], err)
+		}
+	}
+
+	// Collect query data only once. For raw counters this will give us a value at a point in time
+	err = win.PdhCollectQueryData(query)
+	if err != 0 {
+		win.PdhCloseQuery(query)
+		return nil, fmt.Errorf("Error collecting data: %X", err)
+	}
+
+	// For each query PDH will hand back an array of key-value pairs
+	for i := 0; i < len(queries); i++ {
+		bufSize := uint32(0)
+		items := uint32(0)
+
+		// Get the size for the raw data buffer
+		err = win.PdhGetRawCounterArray(counters[i], &bufSize, &items, nil)
+		if err != win.PDH_MORE_DATA {
+			win.PdhCloseQuery(query)
+			return nil, fmt.Errorf("Error getting raw array size: %X", err)
+		}
+		buffer := make([]byte, bufSize)
+		err = win.PdhGetRawCounterArray(counters[i], &bufSize, &items, &buffer[0])
+		if err != 0 {
+			win.PdhCloseQuery(query)
+			return nil, fmt.Errorf("Error getting raw array: %X", err)
+		}
+
+		counters := win.PdhConvertRawCounterArray(items, buffer)
+		for _, item := range counters {
+			keyString := win.UTF16PtrToString(item.SzName)
+			results[keyString] = append(results[keyString], uint64(item.RawValue.FirstValue))
+		}
+	}
+	err = win.PdhCloseQuery(query)
+	if err != 0 {
+		return nil, fmt.Errorf("Error closing query: %X", err)
+	}
+	return results, nil
+}
+
+/* Run the set of provided queries once and report back the raw counter values for each.
+   Queries cannot have a wildcard. Returns an array of results, where the indices in the array
+   match up with the index of the query in `queries`. */
+func runRawPdhQueries(queries []string) ([]uint64, error) {
+	var query win.PDH_HQUERY
+	counters := make([]win.PDH_HCOUNTER, len(queries))
+	results := make([]uint64, 0)
+
+	// Open a new query
+	err := win.PdhOpenQuery(0, 0, &query)
+	if err != 0 {
+		return nil, fmt.Errorf("Error opening PDH query: %X", err)
+	}
+
+	// Add all the counters, give up if any fail
+	for i := 0; i < len(queries); i++ {
+		err = win.PdhAddEnglishCounter(query, queries[i], 0, &counters[i])
+		if err != 0 {
+			win.PdhCloseQuery(query)
+			return nil, fmt.Errorf("Error calling AddCounter for metric %v: %X", queries[i], err)
+		}
+	}
+
+	// Collect query data at a single point in time. This is sufficient for raw counters.
+	err = win.PdhCollectQueryData(query)
+	if err != 0 {
+		win.PdhCloseQuery(query)
+		return nil, fmt.Errorf("Error collecting data: %X", err)
+	}
+
+	// Each query should return a single struct with a 64-bit int value
+	for i := 0; i < len(queries); i++ {
+		counterType := uint32(0)
+		var counter win.PDH_RAW_COUNTER
+		err = win.PdhGetRawCounterValue(counters[i], &counterType, &counter)
+		if err != 0 {
+			win.PdhCloseQuery(query)
+			return nil, fmt.Errorf("Error getting raw value: %X", err)
+		}
+		results = append(results, uint64(counter.FirstValue))
+	}
+	err = win.PdhCloseQuery(query)
+	if err != 0 {
+		return nil, fmt.Errorf("Error closing query: %X", err)
+	}
+	return results, nil
+}

--- a/sigar_windows_test.go
+++ b/sigar_windows_test.go
@@ -29,4 +29,23 @@ var _ = Describe("SigarWindows", func() {
 			Ω(usage.Total).Should(BeNumerically(">", 0))
 		})
 	})
+
+	Describe("Cpu", func() {
+		It("gets CPU stats", func() {
+			cpu := sigar.Cpu{}
+			err := cpu.Get()
+
+			Ω(err).ShouldNot(HaveOccurred())
+			Ω(cpu.Total()).Should(BeNumerically(">", 0))
+		})
+	})
+
+	Describe("CpuList", func() {
+		It("gets CPU stats", func() {
+			cpuList := sigar.CpuList{}
+			err := cpuList.Get()
+			Ω(err).ShouldNot(HaveOccurred())
+			Ω(cpuList.List[0].Total()).Should(BeNumerically(">", 0))
+		})
+	})
 })


### PR DESCRIPTION
Collect total CPU counters for all cores, and individual CPU counters. Only idle, user, system and IRQ are supported. This doesn't add Windows-specific metrics like processor queue length.
