### PR TITLE
ROCANA-4398: SIGAR collects Windows system info

### DIFF
--- a/sigar_windows.go
+++ b/sigar_windows.go
@@ -228,11 +228,13 @@ func (self *FileSystemUsage) Get(path string) error {
 }
 
 func (self *SystemInfo) Get() error {
-	return notImplemented()
+	self.Sysname = "Windows"
+	return nil
 }
 
 func (self *SystemDistribution) Get() error {
-	return notImplemented()
+	self.Description = "Windows"
+	return nil
 }
 
 func notImplemented() error {

--- a/sigar_windows_test.go
+++ b/sigar_windows_test.go
@@ -77,4 +77,22 @@ var _ = Describe("SigarWindows", func() {
 			Ω(cpuList.List[0].Total()).Should(BeNumerically(">", 0))
 		})
 	})
+
+	Describe("SystemInfo", func() {
+		It("gets system info", func() {
+			si := sigar.SystemInfo{}
+			err := si.Get()
+			Ω(err).ShouldNot(HaveOccurred())
+			Ω(si.Sysname).Should(Equal("Windows"))
+		})
+	})
+
+	Describe("SystemDistribution", func() {
+		It("gets system distribution", func() {
+			sd := sigar.SystemDistribution{}
+			err := sd.Get()
+			Ω(err).ShouldNot(HaveOccurred())
+			Ω(sd.Description).Should(Equal("Windows"))
+		})
+	})
 })


### PR DESCRIPTION
This return `Windows` for the `SystemInfo.Sysname` and the `SystemDistribution.Description`. The rest of the fields remain blank for the time being.
