### PR TITLE
ROCANA-6141 Metrics always include 4 cores on machines with fewer than 4 cores

### DIFF
--- a/sigar_windows.go
+++ b/sigar_windows.go
@@ -87,7 +87,7 @@ func (self *CpuList) Get() error {
 	if capacity == 0 {
 		capacity = 4
 	}
-	self.List = make([]Cpu, capacity)
+	self.List = make([]Cpu, 0, capacity)
 	for cpu, counters := range queryResults {
 		index := 0
 		if cpu == "_Total" {


### PR DESCRIPTION
This mixed up capacity and size, so we always had 4 cores - some with 0 total time.
