### PR TITLE
ROCANA-6476 Windows process metrics

### DIFF
--- a/sigar_windows.go
+++ b/sigar_windows.go
@@ -204,7 +204,7 @@ func getPidList() ([]C.DWORD, error) {
 		listSize := C.DWORD(unsafe.Sizeof(procList[0])*uintptr(len))
 		success := C.EnumProcesses(&procList[0], listSize, &sizeRead)
 		if success == C.FALSE {
-			return nil, fmt.Errorf("Failed to enumerate list of processes")
+			return nil, fmt.Errorf("Failed to enumerate list of processes - %v ", C.GetLastError())
 		}
 		// If we've read less than a full array, slice the list down to just the relevant entries
 		if sizeRead < listSize {

--- a/sigar_windows_test.go
+++ b/sigar_windows_test.go
@@ -1,6 +1,7 @@
 package sigar_test
 
 import (
+	"fmt"
 	"os"
 
 	. "github.com/scalingdata/ginkgo"
@@ -95,4 +96,78 @@ var _ = Describe("SigarWindows", func() {
 			Ω(sd.Description).Should(Equal("Windows"))
 		})
 	})
+
+	Describe("ProcessList", func() {
+		It("gets the list of processes", func() {
+			pl := sigar.ProcList{}
+			err := pl.Get()
+			Ω(err).ShouldNot(HaveOccurred())
+			Ω(len(pl.List)).Should(BeNumerically(">", 0))
+		})
+	})
+
+	Describe("ProcessState", func() {
+		It("gets the process detail", func() {
+			pl := sigar.ProcList{}
+			err := pl.Get()	
+			Ω(err).ShouldNot(HaveOccurred())
+			for _, pid := range pl.List {
+				details := sigar.ProcState{}
+				err  := details.Get(pid)
+				fmt.Printf("Pid: %v Name: %v Err: %v\n", pid, details.Name, err)
+			}
+		})
+	})
+
+	Describe("ProcessTime", func() {
+		It("gets the process detail", func() {
+			pl := sigar.ProcList{}
+			err := pl.Get()	
+			Ω(err).ShouldNot(HaveOccurred())
+			for _, pid := range pl.List {
+				details := sigar.ProcTime{}
+				err  := details.Get(pid)
+				fmt.Printf("Pid: %v Start: %v Process: %v Sys: %v Err: %v\n", pid, details.StartTime, details.User, details.Sys, err)
+			}
+		})
+	})
+
+	Describe("ProcessMem", func() {
+		It("gets the process detail", func() {
+			pl := sigar.ProcList{}
+			err := pl.Get()	
+			Ω(err).ShouldNot(HaveOccurred())
+			for _, pid := range pl.List {
+				details := sigar.ProcMem{}
+				err  := details.Get(pid)
+				fmt.Printf("Pid: %v Resident: %v Size: %v Faults: %v Err: %v\n", pid, details.Resident, details.Size, details.PageFaults, err)
+			}
+		})
+	})
+
+	Describe("ProcessIO", func() {
+		It("gets the process detail", func() {
+			pl := sigar.ProcList{}
+			err := pl.Get()	
+			Ω(err).ShouldNot(HaveOccurred())
+			for _, pid := range pl.List {
+				details := sigar.ProcIo{}
+				err  := details.Get(pid)
+				fmt.Printf("Pid: %v Read Ops: %v Read Size: %v Write Ops: %v Write Size: %v Err: %v\n", pid, details.ReadOps, details.ReadBytes, details.WriteOps, details.WriteBytes, err)
+			}
+		})
+	})
+
+	Describe("ProcessExe", func() {
+		It("gets the process detail", func() {
+			pl := sigar.ProcList{}
+			err := pl.Get()	
+			Ω(err).ShouldNot(HaveOccurred())
+			for _, pid := range pl.List {
+				details := sigar.ProcExe{}
+				err  := details.Get(pid)
+				fmt.Printf("Pid: %v Exe:%v Err: %v\n", pid, details.Name, err)
+			}
+		})
+	})		
 })


### PR DESCRIPTION
Add Windows process metrics support. There are some caveats:
- It's not clear how to get the process name (as displayed in the task manager), versus the binary name. This reports this base name of the first module, which will be the executable filename in most cases.
- There doesn't seem to be a canonical way to get the list of arguments for a process.
- The mapping of Windows memory to Linux memory concepts doesn't seem to be exact.
- Long-term we need to build a shim or something for Windows syscalls so there can be better unit tests. Right now we just check that the calls don't crash.
