### PR TITLE
ROCANA-10183: NetConnState implements Stringer interface

### DIFF
--- a/sigar_interface.go
+++ b/sigar_interface.go
@@ -201,6 +201,34 @@ const (
 	ConnStateClosing
 )
 
+func (self NetConnState) String() string {
+	switch self {
+	case ConnStateEstablished:
+		return "established"
+	case ConnStateSynSent:
+		return "syn_sent"
+	case ConnStateSynRecv:
+		return "syn_recv"
+	case ConnStateFinWait1:
+		return "fin_wait1"
+	case ConnStateFinWait2:
+		return "fin_wait2"
+	case ConnStateTimeWait:
+		return "time_wait"
+	case ConnStateClose:
+		return "close"
+	case ConnStateCloseWait:
+		return "close_wait"
+	case ConnStateLastAck:
+		return "last_ack"
+	case ConnStateListen:
+		return "listen"
+	case ConnStateClosing:
+		return "closing"
+	}
+	return ""
+}
+
 type NetConn struct {
 	LocalAddr  net.IP
 	RemoteAddr net.IP

--- a/sigar_interface_test.go
+++ b/sigar_interface_test.go
@@ -234,4 +234,18 @@ var _ = Describe("Sigar", func() {
 		err := dist.Get()
 		Expect(err).ToNot(HaveOccurred())
 	})
+
+	It("returns NetConnState string", func() {
+		Expect(ConnStateEstablished.String()).To(Equal("established"))
+		Expect(ConnStateSynSent.String()).To(Equal("syn_sent"))
+		Expect(ConnStateSynRecv.String()).To(Equal("syn_recv"))
+		Expect(ConnStateFinWait1.String()).To(Equal("fin_wait1"))
+		Expect(ConnStateFinWait2.String()).To(Equal("fin_wait2"))
+		Expect(ConnStateTimeWait.String()).To(Equal("time_wait"))
+		Expect(ConnStateClose.String()).To(Equal("close"))
+		Expect(ConnStateCloseWait.String()).To(Equal("close_wait"))
+		Expect(ConnStateLastAck.String()).To(Equal("last_ack"))
+		Expect(ConnStateListen.String()).To(Equal("listen"))
+		Expect(ConnStateClosing.String()).To(Equal("closing"))
+	})
 })


### PR DESCRIPTION
Adds string values to `NetConnState` to make these easier to render.